### PR TITLE
feat: Replace main logo with a professional SVG design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DSPex
 
 <p align="center">
-  <img src="assets/dspex-logo.svg" alt="DSPex Logo" width="200" height="200">
+  <img src="assets/dspex-logo.svg" alt="DSPex Professional Logo" width="200" height="200">
 </p>
 
 **DSPex** is a comprehensive Elixir implementation of [DSPy](https://github.com/stanfordnlp/dspy) (Declarative Self-improving Language Programs) that provides a unified interface for working with Large Language Models. It combines high-performance native Elixir implementations with seamless Python DSPy integration through [Snakepit](https://github.com/nshkrdotcom/snakepit) for complex ML workflows.

--- a/assets/dspex-logo.svg
+++ b/assets/dspex-logo.svg
@@ -1,14 +1,23 @@
 <svg width="256" height="256" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logoTitle logoDesc">
-  <title id="logoTitle">DSPex Logo</title>
-  <desc id="logoDesc">A hexagonal logo for DSPex. Inside is a purple octopus character with a sad mouth, an antenna, and wearing glowing cyan glasses. Its central tentacles form a cyan arrow, representing a DSPy signature (input -> output).</desc>
-  
+  <title id="logoTitle">DSPex Professional Logo</title>
+  <desc id="logoDesc">A professional logo for DSPex, an Elixir-based orchestrator for DSPy. The logo is a dark hexagon containing a stylized, glowing cyan 'conductor' core. A sleek, purple serpent, representing a high-performance Python (Snakepit/DSPy) process, elegantly coils around the conductor, symbolizing that the core is orchestrating the powerful tool. The design conveys themes of control, power, and intelligence.</desc>
+
   <defs>
+    <!-- Background gradient for the hexagon -->
     <linearGradient id="hexagonGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#2a163b; stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1c0e29; stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#1a1a2e; stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#16213e; stop-opacity:1" />
     </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="1.5" result="coloredBlur"/>
+
+    <!-- Gradient for the serpent's body -->
+    <linearGradient id="serpentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8A2BE2; stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#4B0082; stop-opacity:1" />
+    </linearGradient>
+
+    <!-- Glowing effect for the central conductor -->
+    <filter id="conductorGlow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
       <feMerge>
         <feMergeNode in="coloredBlur"/>
         <feMergeNode in="SourceGraphic"/>
@@ -17,40 +26,24 @@
   </defs>
 
   <!-- Hexagon Background -->
-  <path d="M60 5 L110 32.5 V 87.5 L60 115 L10 87.5 V 32.5 Z" fill="url(#hexagonGradient)" stroke="#4B276A" stroke-width="2"/>
+  <path d="M60 5 L110 32.5 V 87.5 L60 115 L10 87.5 V 32.5 Z" fill="url(#hexagonGradient)" stroke="#0F3460" stroke-width="2"/>
 
-  <!-- Octopus (Centered) -->
+  <!-- Serpent Coiling around the Conductor -->
   <g>
-    <!-- Tentacles (Purple) -->
-    <path d="M25,60 C15,70 15,90 28,95" stroke="#4B276A" stroke-width="4" fill="none" stroke-linecap="round"/>
-    <path d="M95,60 C105,70 105,90 92,95" stroke="#4B276A" stroke-width="4" fill="none" stroke-linecap="round"/>
-    <path d="M38,75 C30,90 35,100 45,100" stroke="#4B276A" stroke-width="4" fill="none" stroke-linecap="round"/>
-    <path d="M82,75 C90,90 85,100 75,100" stroke="#4B276A" stroke-width="4" fill="none" stroke-linecap="round"/>
-    <path d="M30,45 C20,35 25,20 35,22" stroke="#4B276A" stroke-width="4" fill="none" stroke-linecap="round"/>
-    <path d="M90,45 C100,35 95,20 85,22" stroke="#4B276A" stroke-width="4" fill="none" stroke-linecap="round"/>
-
-    <!-- Head and Body -->
-    <path d="M40,50 C40,20 80,20 80,50 C85,60 75,75 60,75 C45,75 35,60 40,50 Z" fill="#4B276A"/>
-
-    <!-- Central Arrow Tentacles (Cyan) -->
-    <g filter="url(#glow)">
-        <!-- Arrow Line -->
-        <path d="M60,74 C60,60, 40,55, 40,45" stroke="#33D1FF" stroke-width="4.5" fill="none" stroke-linecap="round"/>
-        <!-- Arrow Head -->
-        <path d="M60,74 C60,60, 80,55, 80,45" stroke="#33D1FF" stroke-width="4.5" fill="none" stroke-linecap="round"/>
-        <path d="M72,49 L80,45 L76,39" stroke="#33D1FF" stroke-width="4.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-
-    <!-- Character Details (Glasses, Mouth, Antenna) -->
-    <g fill="none" stroke="#33D1FF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-        <!-- Antenna -->
-        <path d="M60,25 V 20" />
-        <!-- Sad Mouth -->
-        <path d="M55,46 Q60,42, 65,46" />
-        <!-- Glasses -->
-        <path d="M 48,35 H 72" /> <!-- Top Bar -->
-        <path d="M 48,35 C 48,42 56,42 56,35" /> <!-- Left Lens Curve -->
-        <path d="M 64,35 C 64,42 72,42 72,35" /> <!-- Right Lens Curve -->
-    </g>
+    <!-- Serpent Body -->
+    <path d="M 45,25 C 10,30 10,90 45,95 L 75,95 C 110,90 110,30 75,25 L 45,25 Z" fill="url(#serpentGradient)" stroke="#E94560" stroke-width="0" />
+    <path d="M 78,35 C 95,40 95,80 78,85" stroke="#9F70FD" stroke-width="5" fill="none" stroke-linecap="round"/>
+    <path d="M 42,35 C 25,40 25,80 42,85" stroke="#9F70FD" stroke-width="5" fill="none" stroke-linecap="round"/>
+    <!-- Serpent Head -->
+    <path d="M 75,25 C 80,20 80,15 75,10 L 68,10" stroke="url(#serpentGradient)" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Serpent Tail -->
+     <path d="M 45,95 C 40,100 40,105 45,110 L 52,110" stroke="url(#serpentGradient)" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
+
+  <!-- Central Conductor (Stylized Eye/Core) -->
+  <g filter="url(#conductorGlow)">
+    <path d="M60,40 L80,60 L60,80 L40,60 Z" fill="#00E5FF" stroke="#A6F6FF" stroke-width="1.5"/>
+    <circle cx="60" cy="60" r="8" fill="#E1F7F5"/>
+  </g>
+
 </svg>


### PR DESCRIPTION
This commit introduces a new, professionally designed SVG logo for DSPex, replacing the previous one in `README.md`.

The new logo is designed to be highly relevant to the project's use case: an Elixir-based DSPy orchestrator that uses a high-performance Python core (Snakepit).

The design features:
- A stylized, glowing cyan "conductor" core, representing Elixir/DSPex's role as an orchestrator.
- A sleek, purple serpent coiling around the core, symbolizing the powerful Python/DSPy processes being managed.
- A modern, dark hexagonal background for a professional look, maintaining some visual continuity with the previous logo's shape.

The `alt` text in `README.md` has also been updated to reflect the new logo's design.